### PR TITLE
Add omero-zarr-pixel-buffer

### DIFF
--- a/components/tools/OmeroJava/test/integration/ExporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ExporterTest.java
@@ -260,16 +260,13 @@ public class ExporterTest extends AbstractServerTest {
      *             Thrown if an error occurred.
      */
     private Image createImageWithROIToExport() throws Exception {
-      //create an import and image
-        File f = File.createTempFile(RandomStringUtils.random(100, false, true),
-                "."+ OME_XML);
+        // Create OME-TIFF file with ROI data
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImageWithROI(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImageWithROI());
         List<Pixels> pix = null;
         try {
             // method tested in ImporterTest
-            pix = importFile(f, OME_XML);
+            pix = importFile(f, OME_TIFF);
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);
@@ -286,16 +283,13 @@ public class ExporterTest extends AbstractServerTest {
      *             Thrown if an error occurred.
      */
     private Image createImageWithAnnotatedDataToExport() throws Exception {
-        //create an import and image
-        File f = File.createTempFile(RandomStringUtils.random(100, false, true),
-                "."+ OME_XML);
+        // Create OME-TIFF file with annotated acquisition data
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImageWithAnnotatedAcquisitionData(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImageWithAnnotatedAcquisitionData());
         List<Pixels> pix = null;
         try {
             // method tested in ImporterTest
-            pix = importFile(f, OME_XML);
+            pix = importFile(f, OME_TIFF);
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);
@@ -312,16 +306,13 @@ public class ExporterTest extends AbstractServerTest {
      *             Thrown if an error occurred.
      */
     private Image createImageToExport() throws Exception {
-        //create an import and image
-        File f = File.createTempFile(RandomStringUtils.random(100, false, true),
-                "." + OME_XML);
+        // Create OME-TIFF file with acquisition data
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImageWithAcquisitionData(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImageWithAcquisitionData());
         List<Pixels> pix = null;
         try {
             // method tested in ImporterTest
-            pix = importFile(f, OME_XML);
+            pix = importFile(f, OME_TIFF);
             return pix.get(0).getImage();
         } catch (Throwable e) {
             throw new Exception("Cannot create image to import", e);

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList.Builder;
 
 import ome.formats.model.UnitsFactory;
 import ome.units.UNITS;
+import ome.xml.model.enums.PixelType;
 import omero.ServerError;
 import omero.api.ITypesPrx;
 import omero.model.*;
@@ -1213,5 +1214,90 @@ public class ModelMockFactory {
         }
         linkMethod.invoke(link, o, a, null); // Last is Ice.Current;
         return link;
+    }
+
+    /**
+     * Creates an OME-TIFF file from OME metadata using Bio-Formats.
+     *
+     * @param ome The OME metadata to convert.
+     * @return A temporary File containing the OME-TIFF.
+     * @throws Exception Thrown if an error occurred.
+     */
+    public File createOMETiffFile(ome.xml.model.OME ome) throws Exception {
+        if (ome == null || ome.sizeOfImageList() == 0) {
+            throw new IllegalArgumentException("OME metadata must contain at least one Image");
+        }
+
+        // Get dimensions from the OME metadata
+        ome.xml.model.Image image = ome.getImage(0);
+        ome.xml.model.Pixels pixels = image.getPixels();
+        int sizeX = pixels.getSizeX().getValue();
+        int sizeY = pixels.getSizeY().getValue();
+        int sizeZ = pixels.getSizeZ().getValue();
+        int sizeC = pixels.getSizeC().getValue();
+        int sizeT = pixels.getSizeT().getValue();
+
+        PixelType pixelType = pixels.getType();
+        if (pixelType == null) {
+            pixelType = PixelType.UINT8;
+        }
+
+        // Step 1: Write OME-XML to temp file (as metadata.ome.xml)
+        File xmlFile = File.createTempFile("metadata", ".ome.xml");
+        xmlFile.deleteOnExit();
+        ome.specification.XMLWriter xmlWriter = new ome.specification.XMLWriter();
+        xmlWriter.writeFile(xmlFile, ome, true);
+
+        // Step 2: Create reader and read the XML
+        loci.formats.ImageReader reader = new loci.formats.ImageReader();
+        reader.setId(xmlFile.getAbsolutePath());
+
+        // Step 3: Create fresh OMEXMLMetadata for writing (has proper internal structure)
+        loci.formats.ome.OMEXMLMetadata meta = (loci.formats.ome.OMEXMLMetadata)
+                loci.formats.MetadataTools.createOMEXMLMetadata();
+
+        // Step 4: Copy metadata from reader and populate pixels
+        // This creates the proper BinData structure needed for writing
+        loci.formats.MetadataTools.populatePixels(meta, reader, false, false);
+
+        // Step 5: Ensure SamplesPerPixel is set for all channels
+        for (int c = 0; c < sizeC; c++) {
+            if (meta.getChannelSamplesPerPixel(0, c) == null) {
+                meta.setChannelSamplesPerPixel(
+                        new ome.xml.model.primitives.PositiveInteger(1), 0, c);
+            }
+        }
+
+        // Step 6: Create OME-TIFF output file
+        File tiffFile = File.createTempFile("ome_tiff_", ".ome.tiff");
+        tiffFile.deleteOnExit();
+
+        // Step 7: Write with OMETiffWriter
+        loci.formats.out.OMETiffWriter writer = new loci.formats.out.OMETiffWriter();
+        writer.setMetadataRetrieve(meta);
+        writer.setId(tiffFile.getAbsolutePath());
+
+        // Step 8: Generate and write pixel data for each plane
+        int bytesPerPixel = loci.formats.FormatTools.getBytesPerPixel(
+                loci.formats.FormatTools.pixelTypeFromString(pixelType.toString()));
+        int planeSize = sizeX * sizeY * bytesPerPixel;
+        byte[] pixelData = new byte[planeSize];
+
+        int planeCount = sizeZ * sizeC * sizeT;
+        for (int plane = 0; plane < planeCount; plane++) {
+            // Generate pattern in pixel data (gradient based on plane)
+            for (int i = 0; i < planeSize; i++) {
+                pixelData[i] = (byte) ((i + plane) % 256);
+            }
+            writer.saveBytes(plane, pixelData);
+        }
+
+        writer.close();
+        reader.close();
+
+        // Cleanup temp XML file
+        xmlFile.delete();
+
+        return tiffFile;
     }
 }

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -1218,6 +1218,8 @@ public class ModelMockFactory {
 
     /**
      * Creates an OME-TIFF file from OME metadata using Bio-Formats.
+     * The full OME model is preserved in the embedded OME-XML, including
+     * ROIs and annotations.
      *
      * @param ome The OME metadata to convert.
      * @return A temporary File containing the OME-TIFF.
@@ -1228,9 +1230,8 @@ public class ModelMockFactory {
             throw new IllegalArgumentException("OME metadata must contain at least one Image");
         }
 
-        // Get dimensions from the OME metadata
-        ome.xml.model.Image image = ome.getImage(0);
-        ome.xml.model.Pixels pixels = image.getPixels();
+        // Get dimensions from the first image
+        ome.xml.model.Pixels pixels = ome.getImage(0).getPixels();
         int sizeX = pixels.getSizeX().getValue();
         int sizeY = pixels.getSizeY().getValue();
         int sizeZ = pixels.getSizeZ().getValue();
@@ -1242,25 +1243,22 @@ public class ModelMockFactory {
             pixelType = PixelType.UINT8;
         }
 
-        // Step 1: Write OME-XML to temp file (as metadata.ome.xml)
+        // Step 1: Serialise the full OME model to a temp .ome.xml companion file.
+        //         XMLWriter preserves ROIs, annotations and all other elements.
         File xmlFile = File.createTempFile("metadata", ".ome.xml");
         xmlFile.deleteOnExit();
-        ome.specification.XMLWriter xmlWriter = new ome.specification.XMLWriter();
-        xmlWriter.writeFile(xmlFile, ome, true);
+        new ome.specification.XMLWriter().writeFile(xmlFile, ome, true);
 
-        // Step 2: Create reader and read the XML
-        loci.formats.ImageReader reader = new loci.formats.ImageReader();
-        reader.setId(xmlFile.getAbsolutePath());
-
-        // Step 3: Create fresh OMEXMLMetadata for writing (has proper internal structure)
+        // Step 2: Attach a fresh OMEXMLMetadata store to the reader *before* opening
+        //         the file so that the reader populates it with the complete parsed
+        //         OME-XML (ROIs, annotations, etc.), not just pixel dimensions.
         loci.formats.ome.OMEXMLMetadata meta = (loci.formats.ome.OMEXMLMetadata)
                 loci.formats.MetadataTools.createOMEXMLMetadata();
+        loci.formats.ImageReader reader = new loci.formats.ImageReader();
+        reader.setMetadataStore(meta);
+        reader.setId(xmlFile.getAbsolutePath());
 
-        // Step 4: Copy metadata from reader and populate pixels
-        // This creates the proper BinData structure needed for writing
-        loci.formats.MetadataTools.populatePixels(meta, reader, false, false);
-
-        // Step 5: Ensure SamplesPerPixel is set for all channels
+        // Step 3: Ensure SamplesPerPixel is set for all channels (required by writer).
         for (int c = 0; c < sizeC; c++) {
             if (meta.getChannelSamplesPerPixel(0, c) == null) {
                 meta.setChannelSamplesPerPixel(
@@ -1268,25 +1266,21 @@ public class ModelMockFactory {
             }
         }
 
-        // Step 6: Create OME-TIFF output file
+        // Step 4: Write the OME-TIFF with the fully populated metadata store.
         File tiffFile = File.createTempFile("ome_tiff_", ".ome.tiff");
         tiffFile.deleteOnExit();
 
-        // Step 7: Write with OMETiffWriter
         loci.formats.out.OMETiffWriter writer = new loci.formats.out.OMETiffWriter();
         writer.setMetadataRetrieve(meta);
         writer.setId(tiffFile.getAbsolutePath());
 
-        // Step 8: Generate and write pixel data for each plane
+        // Step 5: Write synthetic pixel data for each plane.
         int bytesPerPixel = loci.formats.FormatTools.getBytesPerPixel(
                 loci.formats.FormatTools.pixelTypeFromString(pixelType.toString()));
-        int planeSize = sizeX * sizeY * bytesPerPixel;
-        byte[] pixelData = new byte[planeSize];
-
+        byte[] pixelData = new byte[sizeX * sizeY * bytesPerPixel];
         int planeCount = sizeZ * sizeC * sizeT;
         for (int plane = 0; plane < planeCount; plane++) {
-            // Generate pattern in pixel data (gradient based on plane)
-            for (int i = 0; i < planeSize; i++) {
+            for (int i = 0; i < pixelData.length; i++) {
                 pixelData[i] = (byte) ((i + plane) % 256);
             }
             writer.saveBytes(plane, pixelData);
@@ -1294,8 +1288,6 @@ public class ModelMockFactory {
 
         writer.close();
         reader.close();
-
-        // Cleanup temp XML file
         xmlFile.delete();
 
         return tiffFile;

--- a/components/tools/OmeroJava/test/integration/ModelMockFactoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactoryTest.java
@@ -5,48 +5,125 @@
 package integration;
 
 import java.io.File;
+import java.util.Iterator;
 import java.util.List;
 
-import omero.model.Pixels;
-
-import org.testng.annotations.Test;
-
-import ome.xml.model.OME;
 import ome.specification.XMLMockObjects;
+import omero.api.IRoiPrx;
+import omero.api.RoiOptions;
+import omero.api.RoiResult;
+import omero.model.Annotation;
+import omero.model.BooleanAnnotation;
+import omero.model.CommentAnnotation;
+import omero.model.Ellipse;
+import omero.model.IObject;
+import omero.model.ImageAnnotationLink;
+import omero.model.Line;
+import omero.model.LongAnnotation;
+import omero.model.Mask;
+import omero.model.Pixels;
+import omero.model.Point;
+import omero.model.Polyline;
+import omero.model.Rectangle;
+import omero.model.Roi;
+import omero.model.Shape;
+import omero.model.TagAnnotation;
+import omero.model.TermAnnotation;
+import omero.sys.ParametersI;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Tests for ModelMockFactory
  */
 public class ModelMockFactoryTest extends AbstractServerImportTest {
 
+    private static final String OME_TIFF = "ome.tiff";
+
     /**
-     * Test creating and importing an OME-TIFF file
+     * Tests that an OME-TIFF created from an image with ROI data can be
+     * imported and that all expected shapes survive the round-trip.
      */
     @Test
-    public void testCreateOMETiffFile() throws Throwable {
-        // Create mock OME metadata
+    public void testCreateOMETiffFileWithROI() throws Throwable {
         XMLMockObjects xml = new XMLMockObjects();
-        OME ome = xml.createImageWithAcquisitionData();
-
-        // Create OME-TIFF file
-        File tiffFile = null;
+        File tiffFile = mmFactory.createOMETiffFile(xml.createImageWithROI());
         try {
-            tiffFile = mmFactory.createOMETiffFile(ome);
-            System.out.println("Created OME-TIFF: " + tiffFile.getAbsolutePath());
-            System.out.println("File size: " + tiffFile.length() + " bytes");
+            List<Pixels> pixels = importFile(tiffFile, OME_TIFF);
+            Assert.assertNotNull(pixels);
+            Assert.assertFalse(pixels.isEmpty());
 
-            // Import the file
-            List<Pixels> pixels = importFile(tiffFile, "ome.tiff");
+            long imageId = pixels.get(0).getImage().getId().getValue();
 
-            // Verify import succeeded
-            assert pixels != null : "importFile returned null";
-            assert !pixels.isEmpty() : "importFile returned empty list";
+            IRoiPrx roiSvc = factory.getRoiService();
+            RoiResult result = roiSvc.findByImage(imageId, new RoiOptions());
+            Assert.assertNotNull(result);
+            List<Roi> rois = result.rois;
+            Assert.assertNotNull(rois);
+            Assert.assertEquals(rois.size(), XMLMockObjects.SIZE_C.intValue());
 
-            Pixels pix = pixels.get(0);
-            assert pix != null : "First pixel is null";
-            assert pix.getImage() != null : "Image is null";
+            Iterator<Roi> roiIter = rois.iterator();
+            while (roiIter.hasNext()) {
+                Roi roi = roiIter.next();
+                List<Shape> shapes = roi.copyShapes();
+                Assert.assertNotNull(shapes);
+                Assert.assertEquals(shapes.size(), XMLMockObjects.SHAPES.length);
+                int count = 0;
+                for (Shape shape : shapes) {
+                    if (shape instanceof Rectangle || shape instanceof Line
+                            || shape instanceof Ellipse
+                            || shape instanceof Polyline || shape instanceof Mask
+                            || shape instanceof Point) {
+                        count++;
+                    }
+                }
+                Assert.assertEquals(count, XMLMockObjects.SHAPES.length);
+            }
+        } finally {
+            if (tiffFile != null && tiffFile.exists()) {
+                tiffFile.delete();
+            }
+        }
+    }
 
-            System.out.println("Import successful! Image ID: " + pix.getImage().getId().getValue());
+    /**
+     * Tests that an OME-TIFF created from an annotated image can be imported
+     * and that all expected annotation types survive the round-trip.
+     */
+    @Test
+    public void testCreateOMETiffFileWithAnnotations() throws Throwable {
+        XMLMockObjects xml = new XMLMockObjects();
+        File tiffFile = mmFactory.createOMETiffFile(xml.createAnnotatedImage());
+        try {
+            List<Pixels> pixels = importFile(tiffFile, OME_TIFF);
+            Assert.assertNotNull(pixels);
+            Assert.assertFalse(pixels.isEmpty());
+
+            long imageId = pixels.get(0).getImage().getId().getValue();
+
+            String hql = "select l from ImageAnnotationLink as l "
+                    + "left outer join fetch l.parent as p "
+                    + "join fetch l.child "
+                    + "where p.id = :id";
+            List<IObject> links = iQuery.findAllByQuery(hql, new ParametersI().addId(imageId));
+
+            Assert.assertTrue(links.size() >= XMLMockObjects.ANNOTATIONS.length,
+                    String.format("Expected at least %d annotations, got %d",
+                            XMLMockObjects.ANNOTATIONS.length, links.size()));
+
+            int count = 0;
+            for (IObject obj : links) {
+                Annotation a = ((ImageAnnotationLink) obj).getChild();
+                if (a instanceof CommentAnnotation
+                        || a instanceof TagAnnotation
+                        || a instanceof TermAnnotation
+                        || a instanceof BooleanAnnotation
+                        || a instanceof LongAnnotation) {
+                    count++;
+                }
+            }
+            Assert.assertEquals(count, XMLMockObjects.ANNOTATIONS.length);
         } finally {
             if (tiffFile != null && tiffFile.exists()) {
                 tiffFile.delete();

--- a/components/tools/OmeroJava/test/integration/ModelMockFactoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006-2017 University of Dundee. All rights reserved.
+ * Use is subject to license terms supplied in LICENSE.txt
+ */
+package integration;
+
+import java.io.File;
+import java.util.List;
+
+import omero.model.Pixels;
+
+import org.testng.annotations.Test;
+
+import ome.xml.model.OME;
+import ome.specification.XMLMockObjects;
+
+/**
+ * Tests for ModelMockFactory
+ */
+public class ModelMockFactoryTest extends AbstractServerImportTest {
+
+    /**
+     * Test creating and importing an OME-TIFF file
+     */
+    @Test
+    public void testCreateOMETiffFile() throws Throwable {
+        // Create mock OME metadata
+        XMLMockObjects xml = new XMLMockObjects();
+        OME ome = xml.createImageWithAcquisitionData();
+
+        // Create OME-TIFF file
+        File tiffFile = null;
+        try {
+            tiffFile = mmFactory.createOMETiffFile(ome);
+            System.out.println("Created OME-TIFF: " + tiffFile.getAbsolutePath());
+            System.out.println("File size: " + tiffFile.length() + " bytes");
+
+            // Import the file
+            List<Pixels> pixels = importFile(tiffFile, "ome.tiff");
+
+            // Verify import succeeded
+            assert pixels != null : "importFile returned null";
+            assert !pixels.isEmpty() : "importFile returned empty list";
+
+            Pixels pix = pixels.get(0);
+            assert pix != null : "First pixel is null";
+            assert pix.getImage() != null : "Image is null";
+
+            System.out.println("Import successful! Image ID: " + pix.getImage().getId().getValue());
+        } finally {
+            if (tiffFile != null && tiffFile.exists()) {
+                tiffFile.delete();
+            }
+        }
+    }
+}

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -438,14 +438,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineSetters() throws Exception {
-        File file = File.createTempFile("testRenderingEngineSetters", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(file, xml.createImage(), true);
+        File file = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(file, OME_FORMAT);
+            pixels = importFile(file, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1667,14 +1664,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testSaveCurrentSettingsMultipleTimes() throws Exception {
-        File file = File.createTempFile("testRenderingEngineSetters", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(file, xml.createImage(), true);
+        File file = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(file, OME_FORMAT);
+            pixels = importFile(file, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1710,14 +1704,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testSaveCurrentSettingsAll() throws Exception {
-        File file = File.createTempFile("testRenderingEngineSetters", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(file, xml.createImage(), true);
+        File file = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(file, OME_FORMAT);
+            pixels = importFile(file, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -82,6 +82,9 @@ import org.testng.Assert;
  */
 public class RenderingEngineTest extends AbstractServerTest {
 
+    /** The OME-TIFF format. */
+    private static final String OME_TIFF = "ome.tiff";
+
     /** The red mask. */
     private static final int RED_MASK = 0x00ff0000;
 
@@ -118,13 +121,11 @@ public class RenderingEngineTest extends AbstractServerTest {
             boolean preload) throws Exception {
         EventContext ctx = newUserAndGroup(permissions);
         // Import the image
-        File f = File.createTempFile("saveRenderingSettings", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -335,14 +336,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testCreateRenderingEngine() throws Exception {
-        File f = File.createTempFile("testCreateRenderingEngine", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -367,14 +365,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineGetters() throws Exception {
-        File f = File.createTempFile("testRenderingEngineGetters", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -541,14 +536,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testResetDefaultsNoSave() throws Exception {
-        File f = File.createTempFile("testResetDefaultsNoSave", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -588,13 +580,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testResetDefaults() throws Exception {
-        File f = File.createTempFile("testResetDefaults", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -632,14 +622,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testSaveCurrentSettings() throws Exception {
-        File f = File.createTempFile("testSaveCurrentSettings", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -778,13 +765,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderPlane() throws Exception {
-        File f = File.createTempFile("testRenderPlane", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -833,13 +818,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderRegion() throws Exception {
-        File f = File.createTempFile("testRenderRegion", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -914,14 +897,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderRegionChangeModel() throws Exception {
-        File f = File.createTempFile("testRenderRegionChangeModel", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -977,14 +957,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderCompressedPlane() throws Exception {
-        File f = File.createTempFile("testRenderCompressedPlane", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1026,14 +1003,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderCompressedRegion() throws Exception {
-        File f = File.createTempFile("testRenderCompressedRegion", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1080,14 +1054,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPackedIntPlane() throws Exception {
-        File f = File.createTempFile("testRenderAsPackedIntPlane", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1142,14 +1113,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPackedIntRegion() throws Exception {
-        File f = File.createTempFile("testRenderAsPackedIntRegion", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1209,14 +1177,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPackedIntRegionChangeModel() throws Exception {
-        File f = File.createTempFile("testRenderAsPackedIntRegion", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1278,14 +1243,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPackedIntStridePlane() throws Exception {
-        File f = File.createTempFile("testRenderAsPackedIntStridePlane", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1325,14 +1287,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPackedIntStrideRegion() throws Exception {
-        File f = File.createTempFile("testRenderAsPackedIntStrideRegion", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1377,14 +1336,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderCompressedStridePlane() throws Exception {
-        File f = File.createTempFile("testRenderCompressedStridePlane", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1427,14 +1383,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderCompressedStrideRegion() throws Exception {
-        File f = File.createTempFile("testRenderCompressedStridePlane", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1483,13 +1436,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderStridePlane() throws Exception {
-        File f = File.createTempFile("testRenderStridePlane", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1547,14 +1498,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderStrideRegion() throws Exception {
-        File f = File
-                .createTempFile("testRenderStrideRegion", "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1617,14 +1565,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderRegionOutsideRange() throws Exception {
-        File f = File.createTempFile("testRenderRegionOutsideRange", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1671,14 +1616,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderAsPacketIntRegionOutsideRange() throws Exception {
-        File f = File.createTempFile("testRenderRegionOutsideRange", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -1948,14 +1890,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineChannelWindowGetter() throws Exception {
-        File f = File.createTempFile("testRenderingEngineChannelWindowGetter", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2002,14 +1941,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineChannelLookupTable() throws Exception {
-        File f = File.createTempFile("testRenderingEngineChannelLookupTable", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2051,14 +1987,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineProjectionDef() throws Exception {
-        File f = File.createTempFile("testRenderingEngineProjectionDef", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2112,14 +2045,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderingEngineSaveChannelLookupTable() throws Exception {
-        File f = File.createTempFile("testRenderingEngineSaveChannelLookupTable", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2166,14 +2096,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testLutReaders() throws Exception {
         //First import an image
-        File f = File.createTempFile("testLutReaders", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2249,14 +2176,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testLutNotInlist() throws Exception {
         //First import an image
-        File f = File.createTempFile("testLutNotInlist", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2304,14 +2228,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testReverseIntensity() throws Exception {
         //First import an image
-        File f = File.createTempFile("testReverseIntensity", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2356,14 +2277,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testAddAndRemoveCodomain() throws Exception {
         //First import an image
-        File f = File.createTempFile("testAddAndRemoveCodomain", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2403,14 +2321,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testAddCodomainTwice() throws Exception {
         //First import an image
-        File f = File.createTempFile("testAddCodomainTwice", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2450,14 +2365,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testSaveCodomainAndRestart() throws Exception {
         //First import an image
-        File f = File.createTempFile("testSaveCodomainAndRestart", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -2508,14 +2420,11 @@ public class RenderingEngineTest extends AbstractServerTest {
     @Test
     public void testAddRemoveChainAndSave() throws Exception {
         //First import an image
-        File f = File.createTempFile("testAddRemoveChainAndSave", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -4079,14 +3988,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderProjectedCompressed() throws Exception {
-        File f = File.createTempFile("testRenderProjectedCompressed", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -4121,14 +4027,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderProjectedUnCompressed() throws Exception {
-        File f = File.createTempFile("testRenderProjectedCompressed", "."
-                + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -4164,14 +4067,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderProjectedCompressedNoChannels() throws Exception {
-        File f = File.createTempFile("testRenderProjectedCompressedNoChannels",
-                "." + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }
@@ -4210,14 +4110,11 @@ public class RenderingEngineTest extends AbstractServerTest {
      */
     @Test
     public void testRenderProjectedUnCompressedNoChannels() throws Exception {
-        File f = File.createTempFile("testRenderProjectedUnCompressedNoChannels",
-                "."  + OME_FORMAT);
         XMLMockObjects xml = new XMLMockObjects();
-        XMLWriter writer = new XMLWriter();
-        writer.writeFile(f, xml.createImage(), true);
+        File f = mmFactory.createOMETiffFile(xml.createImage());
         List<Pixels> pixels = null;
         try {
-            pixels = importFile(f, OME_FORMAT);
+            pixels = importFile(f, OME_TIFF);
         } catch (Throwable e) {
             throw new Exception("cannot import image", e);
         }

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -85,6 +85,10 @@
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
           root="https://nexus.senbox.net/nexus/content/groups/public/"/>
+      <ibiblio name="gs-artifactory" cache="maven"
+          usepoms="true" useMavenMetadata="true"
+          m2compatible="true"
+          root="https://artifacts.glencoesoftware.com/artifactory/omero-plus/"/>
 
     <!-- Main resolver which has as its first resolver the location
     where all our jars will be published -->
@@ -94,6 +98,7 @@
         <resolver ref="user-maven"/>
         <resolver ref="maven"/>
         <resolver ref="ome-artifactory"/>
+        <resolver ref="gs-artifactory"/>
     </chain>
 
     <!-- Resolver for OME dependencies-->

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -243,7 +243,7 @@ versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-scripts-url=${versions.omero-pypi}
 
 # hard coded, should not be picked up by scc for now!
-versions.omero-zarr-pixel-buffer=0.6.1
+versions.omero-zarr-pixel-buffer=0.7.0-rc1
 
 ###
 ### Appended Values

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -243,7 +243,7 @@ versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-scripts-url=${versions.omero-pypi}
 
 # hard coded, should not be picked up by scc for now!
-versions.omero-zarr-pixel-buffer=0.7.0-rc1
+versions.omero-zarr-pixel-buffer=0.7.0-rc3
 
 ###
 ### Appended Values

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -242,6 +242,9 @@ versions.velocity=1.4
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-scripts-url=${versions.omero-pypi}
 
+# hard coded, should not be picked up by scc for now!
+versions.omero-zarr-pixel-buffer=0.6.1
+
 ###
 ### Appended Values
 ###

--- a/ivy.xml
+++ b/ivy.xml
@@ -17,5 +17,6 @@
     <dependency org="ome" name="formats-gpl" rev="${versions.bioformats}"/>
     <!-- Extensions for bundling into the release -->
     <dependency org="ome" name="OMEZarrReader" rev="${versions.OMEZarrReader}"/>
+    <dependency org="com.glencoesoftware.omero" name="omero-zarr-pixel-buffer" rev="${versions.omero-zarr-pixel-buffer}"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
I'd strongly suggest to add the omero-zarr-pixel-buffer to the omero.server build. Like mentioned in https://github.com/glencoesoftware/omero-zarr-pixel-buffer?tab=readme-ov-file#installation .

The current version 0.6.1 only has 5 additional dependencies. But with Zarr v3 support and move to AWS SDK v2 (https://github.com/ome/omero-zarr-pixel-buffer/pull/13 ) there will be 61 (mostly because AWS SDK v2 is highly modularised in contrast to v1). It would also make it much easier to test in CI.

/cc @jburel 
