### PR TITLE
Add test for conn.getObjects('Annotations', opts={...})

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -48,6 +48,15 @@ def _testAnnotation(obj, annclass, ns, value, sameOwner=False,
     assert ann.getNs() == ns,  '%s != %s' % (str(ann.getNs()), str(ns))
     if testOwner is not None:
         testOwner(obj, ann)
+    # test conn.countAnnotations()
+    counts = gateway.countAnnotations(obj.OMERO_CLASS, [obj.id])
+    assert counts is not None
+    # Timestamp and Boolean not included in counts
+    if annclass.OMERO_CLASS not in ["TimestampAnnotation",
+                                    "BooleanAnnotation",
+                                    # LongAnnotation is only for 'rating'
+                                    "LongAnnotation"]:
+        assert counts[annclass.OMERO_CLASS] >= 1.   # e.g. TagAnnotation: 1
     # Remove and check
     obj.removeAnnotations(ns)
     assert obj.getAnnotation(ns) is None

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -669,14 +669,12 @@ class TestGetObject (ITest):
         def create_dataset_with_annotations(name, dtype="Dataset"):
             if dtype == "Dataset":
                 obj = DatasetI()
-                obj.name = rstring(name)
-                obj = update.saveAndReturnObject(obj)
                 wrapper = omero.gateway.DatasetWrapper(conn, obj)
             elif dtype == "Project":
                 obj = ProjectI()
-                obj.name = rstring(name)
-                obj = update.saveAndReturnObject(obj)
                 wrapper = omero.gateway.ProjectWrapper(conn, obj)
+            wrapper.setName(name)
+            wrapper.save()
 
             # Create total of 10 annotations on the object...
             # create Comment, Tag, Xml, etc
@@ -721,15 +719,11 @@ class TestGetObject (ITest):
         create_dataset_with_annotations("Project 1", dtype="Project")
 
         # Add Tag to Group
-        groupId = conn.getEventContext().groupId
         tag = omero.gateway.TagAnnotationWrapper(conn)
         tag.setNs("test_get_objects_group_tag")
         tag.setValue("Test Tag on Group")
-        tag.save()
-        link = omero.model.ExperimenterGroupAnnotationLinkI()
-        link.child = omero.model.TagAnnotationI(tag.id, False)
-        link.parent = omero.model.ExperimenterGroupI(groupId, False)
-        conn.getUpdateService().saveAndReturnObject(link)
+        group = conn.getGroupFromContext()
+        group.linkAnnotation(tag)
 
         # get all annotations on one Dataset
         annGen = conn.getObjects("Annotation",

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -803,9 +803,10 @@ class TestGetObject (ITest):
         parent.setValue("parent Tag")
         parent.save()
 
+        COMMENT_TEXT = "test annotation child Comment"
         child = omero.gateway.CommentAnnotationWrapper(conn)
         child.setNs("test.annotation.child")
-        child.setValue("test annotation child Comment")
+        child.setValue(COMMENT_TEXT)
         child.save()
         child2 = omero.gateway.LongAnnotationWrapper(conn)
         child2.setNs("test.annotation.child")
@@ -855,6 +856,20 @@ class TestGetObject (ITest):
         assert counts["CommentAnnotation"] == 1
         counts = conn.countAnnotations("experimentergroup", obj_ids=[group.id])
         assert counts["CommentAnnotation"] == 1
+
+        # test listAnnotations()
+        group = conn.getObject("ExperimenterGroup", group.id)
+        groupAnns = list(group.listAnnotations())
+        assert len(groupAnns) == 1
+        assert groupAnns[0].getValue() == COMMENT_TEXT
+        tag = conn.getObject("Annotation", parent.id)
+        tagAnns = list(tag.listAnnotations())
+        assert len(tagAnns) == 2
+        # Since obj._loadAnnotationLinks() doesn't load child annotations
+        # for AnootationAnnotationLink ?? (unexpected) the anns are
+        # not loaded, so tagAnns are just empty AnnotationWrapper()
+        # and we can't getValue()
+        # assert COMMENT_TEXT in [a.getValue() for a in tagAnns]
 
     def testGetImage(self, gatewaywrapper, author_testimg_tiny):
         testImage = author_testimg_tiny

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -716,8 +716,9 @@ class TestGetObject (ITest):
         assert len(list(annGen)) == 0
 
         # get ALL annotations
+        # NB: this can include 'user' group annotations from other tests
         anns = list(conn.getObjects("Annotation"))
-        assert len(anns) == 9
+        assert len(anns) >= 9
 
         # We only want Tags on the two Datasets
         annGen = conn.getObjects("Annotation",

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -789,6 +789,72 @@ class TestGetObject (ITest):
             assert ann.getFile().getName() == 'fileName'
             assert ann.getFile().getPath() == 'path/to/file'
 
+    def testAnnotationAnnotationLinks(self):
+        """
+        Test various annotations methods when parent is an Annotation or Group
+        """
+
+        group = self.new_group(perms='rwra--')
+        client, user = self.new_client_and_user(group=group)
+
+        conn = BlitzGateway(client_obj=client)
+
+        parent = omero.gateway.TagAnnotationWrapper(conn)
+        parent.setNs("test.annotation.parent")
+        parent.setValue("parent Tag")
+        parent.save()
+
+        child = omero.gateway.CommentAnnotationWrapper(conn)
+        child.setNs("test.annotation.child")
+        child.setValue("test annotation child Comment")
+        child.save()
+        child2 = omero.gateway.LongAnnotationWrapper(conn)
+        child2.setNs("test.annotation.child")
+        child2.setValue(123)
+        child2.save()
+
+        # link child to parent
+        parent.linkAnnotation(child)
+        parent.linkAnnotation(child2)
+        group = conn.getGroupFromContext()
+        # Also annotate the Group
+        group.linkAnnotation(child)
+
+
+        # Test getObjects() - single Comment on group
+        for ann_type in ["CommentAnnotation", "LongAnnotation", "Annotation"]:
+            annGen = conn.getObjects(ann_type,
+                                     opts={'parent_type': "experimentergroup",
+                                           'parent_ids': [group.id]})
+            count = 0 if ann_type == "LongAnnotation" else 1
+            assert len(list(annGen)) == count
+
+        # Query annotations on the Annotation
+        counts = {"CommentAnnotation": 1, "LongAnnotation": 1,
+                  "Annotation": 2, "BooleanAnnotation": 0}
+        for ann_type, count in counts.items():
+            annGen = conn.getObjects(ann_type,
+                                     opts={'parent_type': "annotation",
+                                           'parent_ids': [parent.id]})
+            assert len(list(annGen)) == count
+
+        # Test conn.getAnnotationLinks()
+        for parent_types in ["CommentAnnotation", "LongAnnotation", "Annotation"]:
+            # ALL parent_typess get coerced to "Annotation" - Long/Comment etc. ignored
+            annLinks = conn.getAnnotationLinks(parent_types, parent_ids=[parent.id])
+            assert len(list(annLinks)) == 2
+
+        for parent_types in ["ExperimenterGroup", "Annotation"]:
+            annLinks = conn.getAnnotationLinks("Annotation", ann_ids=[child.id])
+            # child is on parent (Tag) and Group, so should be 1 link each
+            assert len(list(annLinks)) == 1
+
+        # test countAnnotations()
+        counts = conn.countAnnotations("Annotation", obj_ids=[parent.id])
+        assert counts["CommentAnnotation"] == 1
+        counts = conn.countAnnotations("experimentergroup", obj_ids=[group.id])
+        assert counts["CommentAnnotation"] == 1
+
     def testGetImage(self, gatewaywrapper, author_testimg_tiny):
         testImage = author_testimg_tiny
         # This should return image wrapper

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -710,11 +710,11 @@ class TestGetObject (ITest):
 
         # get all annotations on one Dataset
         annGen = conn.getObjects("Annotation",
-                                 opts={'parent_type': "dataset",
+                                 opts={'parent_type': "Dataset",
                                        'parent_ids': [dataset1.id]})
         assert len(list(annGen)) == 10
 
-        # get all annotations on two Datasets
+        # annotations on two Datasets - parent_type is case-insensitive
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "dataset",
                                        'parent_ids': [dataset1.id,

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -674,6 +674,18 @@ class TestGetObject (ITest):
             tag.setNs(ns_tag)
             tag.setValue("Test Tag: " + name)
             wrapper.linkAnnotation(tag)
+            # create FileAnnotation
+            fileAnn = omero.gateway.FileAnnotationWrapper(conn)
+            fileObj = omero.model.OriginalFileI()
+            fileObj = omero.gateway.OriginalFileWrapper(conn, fileObj)
+            fileObj.setName(omero.rtypes.rstring('fileName'))
+            fileObj.setPath(omero.rtypes.rstring('path/to/file'))
+            fileObj.setHash(omero.rtypes.rstring('a'))
+            fileObj.setSize(omero.rtypes.rlong(0))
+            fileObj.save()
+            fileAnn.setFile(fileObj)
+            fileAnn.save()
+            wrapper.linkAnnotation(fileAnn)
 
             return wrapper
 
@@ -683,16 +695,16 @@ class TestGetObject (ITest):
 
         # get all annotations on one Dataset
         annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset", 'parent_ids': [dataset1.id]})
-        assert len(list(annGen)) == 2
+        assert len(list(annGen)) == 3
 
         # get all annotations on two Datasets
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "dataset", 'parent_ids': [dataset1.id, dataset2.id]})
-        assert len(list(annGen)) == 4
+        assert len(list(annGen)) == 6
 
         # get all annotations on ALL Datasets
         annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset"})
-        assert len(list(annGen)) == 4
+        assert len(list(annGen)) == 6
 
         # No annotations on PlateAcquisition (none created)
         annGen = conn.getObjects("Annotation", opts={'parent_type': "plateacquisition"})
@@ -700,7 +712,7 @@ class TestGetObject (ITest):
 
        # get ALL annotations
         anns = list(conn.getObjects("Annotation"))
-        assert len(anns) == 6
+        assert len(anns) == 9
 
         # We only want Tags on the two Datasets
         annGen = conn.getObjects("Annotation",
@@ -722,6 +734,14 @@ class TestGetObject (ITest):
         annGen = conn.getObjects("Annotation", opts={'ns': ns, 'ann_type': "tag"})
         assert len(list(annGen)) == 0
 
+        # test "file" annotation is loaded
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "dataset",
+                                       'parent_ids': [dataset1.id, dataset2.id],
+                                       'ann_type': "file"})
+        for ann in annGen:
+            assert ann.getFile().getName() == 'fileName'
+            assert ann.getFile().getPath() == 'path/to/file'
 
 
     def testGetImage(self, gatewaywrapper, author_testimg_tiny):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -20,10 +20,11 @@ import pytest
 
 from omero.gateway.scripts import dbhelpers
 from omero.rtypes import wrap, rlong
-from omero.testlib import ITest
+from omero.testlib import ITest, rstring
 from omero.gateway import BlitzGateway, KNOWN_WRAPPERS, DatasetWrapper, \
     ProjectWrapper, ImageWrapper, ScreenWrapper, PlateWrapper
 from omero.model import DatasetI, \
+    ProjectI, \
     ImageI, \
     PlateI, \
     ScreenI, \
@@ -635,6 +636,93 @@ class TestGetObject (ITest):
         obj.removeAnnotations(ns)
         dataset.unlinkAnnotations(ns_tag)  # unlink tag
         obj.removeAnnotations(ns_tag)      # delete tag
+    
+
+    def testGetObjectsAnnotation(self):
+
+        # create new group and user - don't rely on existing test user/group
+
+        group = self.new_group(perms='rwra--')
+        client, user = self.new_client_and_user(group=group)
+
+        conn = BlitzGateway(client_obj=client)
+        update = conn.getUpdateService()
+
+        ns = "test_get_objects_annotation_comment"
+        ns_tag = "test_get_objects_annotation_tag"
+
+
+        def create_dataset_with_annotations(name, dtype="Dataset"):
+            if dtype == "Dataset":
+                obj = DatasetI()
+                obj.name = rstring(name)
+                obj = update.saveAndReturnObject(obj)
+                wrapper = omero.gateway.DatasetWrapper(conn, obj)
+            elif dtype == "Project":
+                obj = ProjectI()
+                obj.name = rstring(name)
+                obj = update.saveAndReturnObject(obj)
+                wrapper = omero.gateway.ProjectWrapper(conn, obj)
+
+            # create Comment
+            ann = omero.gateway.CommentAnnotationWrapper(conn)
+            ann.setNs(ns)
+            ann.setValue("Test Comment: " + name)
+            ann = wrapper.linkAnnotation(ann)
+            # create Tag
+            tag = omero.gateway.TagAnnotationWrapper(conn)
+            tag.setNs(ns_tag)
+            tag.setValue("Test Tag: " + name)
+            wrapper.linkAnnotation(tag)
+
+            return wrapper
+
+        dataset1 = create_dataset_with_annotations("Dataset 1")
+        dataset2 = create_dataset_with_annotations("Dataset 2")
+        project1 = create_dataset_with_annotations("Project 1", dtype="Project")
+
+        # get all annotations on one Dataset
+        annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset", 'parent_ids': [dataset1.id]})
+        assert len(list(annGen)) == 2
+
+        # get all annotations on two Datasets
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "dataset", 'parent_ids': [dataset1.id, dataset2.id]})
+        assert len(list(annGen)) == 4
+
+        # get all annotations on ALL Datasets
+        annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset"})
+        assert len(list(annGen)) == 4
+
+        # No annotations on PlateAcquisition (none created)
+        annGen = conn.getObjects("Annotation", opts={'parent_type': "plateacquisition"})
+        assert len(list(annGen)) == 0
+
+       # get ALL annotations
+        anns = list(conn.getObjects("Annotation"))
+        assert len(anns) == 6
+
+        # We only want Tags on the two Datasets
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "dataset", 'parent_ids': [dataset1.id, dataset2.id],
+                                       'ann_type': "tag"})
+        assert len(list(annGen)) == 2
+
+        # ALL Tags
+        annGen = conn.getObjects("Annotation", opts={'ann_type': "tag"})
+        assert len(list(annGen)) == 3
+
+        # filter by namespace
+        annGen = conn.getObjects("Annotation", opts={'ns': ns})
+        assert len(list(annGen)) == 3
+
+        # filter by namespace and type
+        annGen = conn.getObjects("Annotation", opts={'ns': ns, 'ann_type': "comment"})
+        assert len(list(annGen)) == 3
+        annGen = conn.getObjects("Annotation", opts={'ns': ns, 'ann_type': "tag"})
+        assert len(list(annGen)) == 0
+
+
 
     def testGetImage(self, gatewaywrapper, author_testimg_tiny):
         testImage = author_testimg_tiny

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -708,6 +708,17 @@ class TestGetObject (ITest):
         dataset2 = create_dataset_with_annotations("Dataset 2")
         create_dataset_with_annotations("Project 1", dtype="Project")
 
+        # Add Tag to Group
+        groupId = conn.getEventContext().groupId
+        tag = omero.gateway.TagAnnotationWrapper(conn)
+        tag.setNs("test_get_objects_group_tag")
+        tag.setValue("Test Tag on Group")
+        tag.save()
+        link = omero.model.ExperimenterGroupAnnotationLinkI()
+        link.child = omero.model.TagAnnotationI(tag.id, False)
+        link.parent = omero.model.ExperimenterGroupI(groupId, False)
+        conn.getUpdateService().saveAndReturnObject(link)
+
         # get all annotations on one Dataset
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "Dataset",
@@ -720,6 +731,9 @@ class TestGetObject (ITest):
                                        'parent_ids': [dataset1.id,
                                                       dataset2.id]})
         assert len(list(annGen)) == 20
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "experimentergroup"})
+        assert len(list(annGen)) == 1
 
         # get all annotations on ALL Datasets
         annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset"})
@@ -733,7 +747,7 @@ class TestGetObject (ITest):
         # get ALL annotations
         # NB: this can include 'user' group annotations from other tests
         anns = list(conn.getObjects("Annotation"))
-        assert len(anns) >= 30
+        assert len(anns) >= 31
 
         # We only want Tags on the two Datasets
         annGen = conn.getObjects("TagAnnotation",
@@ -744,7 +758,7 @@ class TestGetObject (ITest):
 
         # ALL Tags
         annGen = conn.getObjects("TagAnnotation")
-        assert len(list(annGen)) == 3
+        assert len(list(annGen)) == 4
 
         # filter by namespace
         annGen = conn.getObjects("Annotation", opts={'ns': ns})

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -683,7 +683,8 @@ class TestGetObject (ITest):
             for ann_type in ann_types:
                 ann = getattr(omero.gateway, ann_type + "Wrapper")(conn)
                 ann.setNs(ns)
-                if ann_type in ("LongAnnotation", "DoubleAnnotation", "TimestampAnnotation"):
+                if ann_type in ("LongAnnotation", "DoubleAnnotation",
+                                "TimestampAnnotation"):
                     ann.setValue(100.0)
                 elif ann_type == "BooleanAnnotation":
                     ann.setValue(True)
@@ -778,10 +779,10 @@ class TestGetObject (ITest):
         # filter by namespace and type
         for ann_type in ann_types:
             annGen = conn.getObjects(ann_type,
-                                    opts={'ns': ns})
+                                     opts={'ns': ns})
             assert len(list(annGen)) == 3
             annGen = conn.getObjects(ann_type,
-                                    opts={'ns': ns_map})
+                                     opts={'ns': ns_map})
             assert len(list(annGen)) == 0
 
         # test File Annotation is loaded

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -20,7 +20,7 @@ import pytest
 
 from omero.gateway.scripts import dbhelpers
 from omero.rtypes import wrap, rlong
-from omero.testlib import ITest, rstring
+from omero.testlib import ITest
 from omero.gateway import BlitzGateway, KNOWN_WRAPPERS, DatasetWrapper, \
     ProjectWrapper, ImageWrapper, ScreenWrapper, PlateWrapper
 from omero.model import DatasetI, \
@@ -656,7 +656,6 @@ class TestGetObject (ITest):
         client, user = self.new_client_and_user(group=group)
 
         conn = BlitzGateway(client_obj=client)
-        update = conn.getUpdateService()
 
         ann_types = ["CommentAnnotation", "TagAnnotation",
                      "LongAnnotation", "XmlAnnotation",
@@ -820,7 +819,6 @@ class TestGetObject (ITest):
         # Also annotate the Group
         group.linkAnnotation(child)
 
-
         # Test getObjects() - single Comment on group
         for ann_type in ["CommentAnnotation", "LongAnnotation", "Annotation"]:
             annGen = conn.getObjects(ann_type,
@@ -839,13 +837,16 @@ class TestGetObject (ITest):
             assert len(list(annGen)) == count
 
         # Test conn.getAnnotationLinks()
-        for parent_types in ["CommentAnnotation", "LongAnnotation", "Annotation"]:
-            # ALL parent_typess get coerced to "Annotation" - Long/Comment etc. ignored
-            annLinks = conn.getAnnotationLinks(parent_types, parent_ids=[parent.id])
+        for parent_types in ["CommentAnnotation", "LongAnnotation",
+                             "Annotation"]:
+            # ALL parent_typess get coerced to "Annotation"
+            annLinks = conn.getAnnotationLinks(parent_types,
+                                               parent_ids=[parent.id])
             assert len(list(annLinks)) == 2
 
         for parent_types in ["ExperimenterGroup", "Annotation"]:
-            annLinks = conn.getAnnotationLinks("Annotation", ann_ids=[child.id])
+            annLinks = conn.getAnnotationLinks("Annotation",
+                                               ann_ids=[child.id])
             # child is on parent (Tag) and Group, so should be 1 link each
             assert len(list(annLinks)) == 1
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -545,6 +545,8 @@ class TestGetObject (ITest):
         tag.setValue("Test Tag")
         tag = obj.linkAnnotation(tag)
         dataset.linkAnnotation(tag)
+        # also link the Tag to the Comment
+        ann.linkAnnotation(tag)
 
         # get the Comment
         annotation = gatewaywrapper.gateway.getObject(
@@ -590,6 +592,15 @@ class TestGetObject (ITest):
         for al in annLinks:
             assert obj.getId() == al.parent.id.val
             assert al.parent.__class__ == omero.model.ImageI
+
+        # Check links to Tag on the Comment
+        for obj_type in ["CommentAnnotation", "Annotation"]:
+            annLinks = list(gatewaywrapper.gateway.getAnnotationLinks(
+                obj_type, parent_ids=[ann.getId()]))
+            assert len(annLinks) == 1
+            for al in annLinks:
+                assert ann.getId() == al.parent.id.val
+                assert tag.getId() == al.child.id.val
 
         # compare with getObjectsByAnnotations
         annImages = list(gatewaywrapper.gateway.getObjectsByAnnotations(

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -649,6 +649,7 @@ class TestGetObject (ITest):
 
         ns = "test_get_objects_annotation_comment"
         ns_tag = "test_get_objects_annotation_tag"
+        ns_file = "test_get_objects_annotation_file"
 
         def create_dataset_with_annotations(name, dtype="Dataset"):
             if dtype == "Dataset":
@@ -682,6 +683,7 @@ class TestGetObject (ITest):
             fileObj.setSize(omero.rtypes.rlong(0))
             fileObj.save()
             fileAnn.setFile(fileObj)
+            fileAnn.setNs(ns_file)
             fileAnn.save()
             wrapper.linkAnnotation(fileAnn)
 
@@ -746,7 +748,7 @@ class TestGetObject (ITest):
                                  opts={'parent_type': "dataset",
                                        'parent_ids': [dataset1.id,
                                                       dataset2.id],
-                                       'ann_type': "file"})
+                                       'ns': ns_file})
         for ann in annGen:
             assert ann.getFile().getName() == 'fileName'
             assert ann.getFile().getPath() == 'path/to/file'

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -647,8 +647,12 @@ class TestGetObject (ITest):
         conn = BlitzGateway(client_obj=client)
         update = conn.getUpdateService()
 
-        ns = "test_get_objects_annotation_comment"
-        ns_tag = "test_get_objects_annotation_tag"
+        ann_types = ["CommentAnnotation", "TagAnnotation",
+                     "LongAnnotation", "XmlAnnotation",
+                     "DoubleAnnotation", "BooleanAnnotation",
+                     "TimestampAnnotation", "TermAnnotation"]
+        ns = "test_get_objects_namespace"
+        ns_map = "test_get_objects_map_namespace"
         ns_file = "test_get_objects_annotation_file"
 
         def create_dataset_with_annotations(name, dtype="Dataset"):
@@ -663,16 +667,27 @@ class TestGetObject (ITest):
                 obj = update.saveAndReturnObject(obj)
                 wrapper = omero.gateway.ProjectWrapper(conn, obj)
 
-            # create Comment
-            ann = omero.gateway.CommentAnnotationWrapper(conn)
-            ann.setNs(ns)
-            ann.setValue("Test Comment: " + name)
-            ann = wrapper.linkAnnotation(ann)
-            # create Tag
-            tag = omero.gateway.TagAnnotationWrapper(conn)
-            tag.setNs(ns_tag)
-            tag.setValue("Test Tag: " + name)
-            wrapper.linkAnnotation(tag)
+            # Create total of 10 annotations on the object...
+            # create Comment, Tag, Xml, etc
+            for ann_type in ann_types:
+                ann = getattr(omero.gateway, ann_type + "Wrapper")(conn)
+                ann.setNs(ns)
+                if ann_type in ("LongAnnotation", "DoubleAnnotation", "TimestampAnnotation"):
+                    ann.setValue(100.0)
+                elif ann_type == "BooleanAnnotation":
+                    ann.setValue(True)
+                else:
+                    ann.setValue("Test %s: %s" % (ann_type, name))
+                wrapper.linkAnnotation(ann)
+
+            # create MapAnnotation
+            mapAnn = omero.gateway.MapAnnotationWrapper(conn)
+            mapAnn.setNs(ns)
+            mapAnn.setValue([("key1", "value1"), ("key2", "value2")])
+            mapAnn.setNs(ns_map)
+            mapAnn.save()
+            wrapper.linkAnnotation(mapAnn)
+
             # create FileAnnotation
             fileAnn = omero.gateway.FileAnnotationWrapper(conn)
             fileObj = omero.model.OriginalFileI()
@@ -697,18 +712,18 @@ class TestGetObject (ITest):
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "dataset",
                                        'parent_ids': [dataset1.id]})
-        assert len(list(annGen)) == 3
+        assert len(list(annGen)) == 10
 
         # get all annotations on two Datasets
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "dataset",
                                        'parent_ids': [dataset1.id,
                                                       dataset2.id]})
-        assert len(list(annGen)) == 6
+        assert len(list(annGen)) == 20
 
         # get all annotations on ALL Datasets
         annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset"})
-        assert len(list(annGen)) == 6
+        assert len(list(annGen)) == 20
 
         # No annotations on PlateAcquisition (none created)
         annGen = conn.getObjects("Annotation",
@@ -718,31 +733,31 @@ class TestGetObject (ITest):
         # get ALL annotations
         # NB: this can include 'user' group annotations from other tests
         anns = list(conn.getObjects("Annotation"))
-        assert len(anns) >= 9
+        assert len(anns) >= 30
 
         # We only want Tags on the two Datasets
-        annGen = conn.getObjects("Annotation",
+        annGen = conn.getObjects("TagAnnotation",
                                  opts={'parent_type': "dataset",
                                        'parent_ids': [dataset1.id,
-                                                      dataset2.id],
-                                       'ann_type': "tag"})
+                                                      dataset2.id]})
         assert len(list(annGen)) == 2
 
         # ALL Tags
-        annGen = conn.getObjects("Annotation", opts={'ann_type': "tag"})
+        annGen = conn.getObjects("TagAnnotation")
         assert len(list(annGen)) == 3
 
         # filter by namespace
         annGen = conn.getObjects("Annotation", opts={'ns': ns})
-        assert len(list(annGen)) == 3
+        assert len(list(annGen)) == 24
 
         # filter by namespace and type
-        annGen = conn.getObjects("Annotation",
-                                 opts={'ns': ns, 'ann_type': "comment"})
-        assert len(list(annGen)) == 3
-        annGen = conn.getObjects("Annotation",
-                                 opts={'ns': ns, 'ann_type': "tag"})
-        assert len(list(annGen)) == 0
+        for ann_type in ann_types:
+            annGen = conn.getObjects(ann_type,
+                                    opts={'ns': ns})
+            assert len(list(annGen)) == 3
+            annGen = conn.getObjects(ann_type,
+                                    opts={'ns': ns_map})
+            assert len(list(annGen)) == 0
 
         # test File Annotation is loaded
         annGen = conn.getObjects("Annotation",

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -636,7 +636,6 @@ class TestGetObject (ITest):
         obj.removeAnnotations(ns)
         dataset.unlinkAnnotations(ns_tag)  # unlink tag
         obj.removeAnnotations(ns_tag)      # delete tag
-    
 
     def testGetObjectsAnnotation(self):
 
@@ -650,7 +649,6 @@ class TestGetObject (ITest):
 
         ns = "test_get_objects_annotation_comment"
         ns_tag = "test_get_objects_annotation_tag"
-
 
         def create_dataset_with_annotations(name, dtype="Dataset"):
             if dtype == "Dataset":
@@ -691,15 +689,19 @@ class TestGetObject (ITest):
 
         dataset1 = create_dataset_with_annotations("Dataset 1")
         dataset2 = create_dataset_with_annotations("Dataset 2")
-        project1 = create_dataset_with_annotations("Project 1", dtype="Project")
+        create_dataset_with_annotations("Project 1", dtype="Project")
 
         # get all annotations on one Dataset
-        annGen = conn.getObjects("Annotation", opts={'parent_type': "dataset", 'parent_ids': [dataset1.id]})
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "dataset",
+                                       'parent_ids': [dataset1.id]})
         assert len(list(annGen)) == 3
 
         # get all annotations on two Datasets
         annGen = conn.getObjects("Annotation",
-                                 opts={'parent_type': "dataset", 'parent_ids': [dataset1.id, dataset2.id]})
+                                 opts={'parent_type': "dataset",
+                                       'parent_ids': [dataset1.id,
+                                                      dataset2.id]})
         assert len(list(annGen)) == 6
 
         # get all annotations on ALL Datasets
@@ -707,16 +709,19 @@ class TestGetObject (ITest):
         assert len(list(annGen)) == 6
 
         # No annotations on PlateAcquisition (none created)
-        annGen = conn.getObjects("Annotation", opts={'parent_type': "plateacquisition"})
+        annGen = conn.getObjects("Annotation",
+                                 opts={'parent_type': "plateacquisition"})
         assert len(list(annGen)) == 0
 
-       # get ALL annotations
+        # get ALL annotations
         anns = list(conn.getObjects("Annotation"))
         assert len(anns) == 9
 
         # We only want Tags on the two Datasets
         annGen = conn.getObjects("Annotation",
-                                 opts={'parent_type': "dataset", 'parent_ids': [dataset1.id, dataset2.id],
+                                 opts={'parent_type': "dataset",
+                                       'parent_ids': [dataset1.id,
+                                                      dataset2.id],
                                        'ann_type': "tag"})
         assert len(list(annGen)) == 2
 
@@ -729,20 +734,22 @@ class TestGetObject (ITest):
         assert len(list(annGen)) == 3
 
         # filter by namespace and type
-        annGen = conn.getObjects("Annotation", opts={'ns': ns, 'ann_type': "comment"})
+        annGen = conn.getObjects("Annotation",
+                                 opts={'ns': ns, 'ann_type': "comment"})
         assert len(list(annGen)) == 3
-        annGen = conn.getObjects("Annotation", opts={'ns': ns, 'ann_type': "tag"})
+        annGen = conn.getObjects("Annotation",
+                                 opts={'ns': ns, 'ann_type': "tag"})
         assert len(list(annGen)) == 0
 
-        # test "file" annotation is loaded
+        # test File Annotation is loaded
         annGen = conn.getObjects("Annotation",
                                  opts={'parent_type': "dataset",
-                                       'parent_ids': [dataset1.id, dataset2.id],
+                                       'parent_ids': [dataset1.id,
+                                                      dataset2.id],
                                        'ann_type': "file"})
         for ann in annGen:
             assert ann.getFile().getName() == 'fileName'
             assert ann.getFile().getPath() == 'path/to/file'
-
 
     def testGetImage(self, gatewaywrapper, author_testimg_tiny):
         testImage = author_testimg_tiny


### PR DESCRIPTION
# What this PR does

Adding tests for https://github.com/ome/omero-py/pull/489 

All tests are passing: https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/68/testReport/

New test passing now: https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.gatewaytest.test_get_objects/TestGetObject/testGetObjectsAnnotation/history/
