### PR TITLE
Fix the failure of the test_cleanse.py

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -152,7 +152,10 @@ class TestCleanseFullAdmin(CLITest):
         out, err = capsys.readouterr()
         assert not os.path.exists(orig_file_path)
         assert not os.path.isfile(orig_file_path_and_name)
-        assert not os.path.exists(logfile_path)
+        # The log file itself must be removed. On NFS, if another process still
+        # has the deleted file open, the parent directory may temporarily contain
+        # a hidden ".nfs*" file, so its removal cannot be asserted here.
+	    #assert not os.path.exists(logfile_path)
         assert not os.path.isfile(logfile_path_and_name)
 
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -152,10 +152,11 @@ class TestCleanseFullAdmin(CLITest):
         out, err = capsys.readouterr()
         assert not os.path.exists(orig_file_path)
         assert not os.path.isfile(orig_file_path_and_name)
-        # The log file itself must be removed. On NFS, if another process still
-        # has the deleted file open, the parent directory may temporarily contain
+        # The log file itself must be removed.
+        # On NFS, if another process still
+        # has the deleted file open, the parent
+        # directory may temporarily contain
         # a hidden ".nfs*" file, so its removal cannot be asserted here.
-	    #assert not os.path.exists(logfile_path)
         assert not os.path.isfile(logfile_path_and_name)
 
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -153,7 +153,9 @@ class TestCleanseFullAdmin(CLITest):
         assert not os.path.exists(orig_file_path)
         assert not os.path.isfile(orig_file_path_and_name)
         # The log file itself must be removed.
-        # On NFS, if another process still
+        # On NFS, the Blitz process is holding the
+        # file in ManagedRepository as well as other files
+        # in FullText folder (indexer). Until Blitz
         # has the deleted file open, the parent
         # directory may temporarily contain
         # a hidden ".nfs*" file, so its removal cannot be asserted here.


### PR DESCRIPTION
# What this PR does

The failing test is https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/11/testReport/junit/OmeroPy.test.integration.clitest.test_cleanse/TestCleanseFullAdmin/testCleanseNonsenseName/
This PR is removing a line in the ``test_cleanse.py``. 

The assertion in that line which checks the existence of a path to a logfile which should have been deleted is not possible on NFS, because: 

As the Blitz process is still holding the logfile open, on NFS this file cannot be deleted by NFS although the ``cleanse`` script deletes it - it leaves a hidden file behind which the NFS renames to ``...nfs``.


# Testing this PR

Check that the Jenkins build testintegration job is green. 


# Related reading

See https://github.com/ome/openmicroscopy/issues/6461

cc @joshmoore @jburel @sbesson 
